### PR TITLE
dropdown and KeymapMovementMixin shouldn't use same KEYMAP

### DIFF
--- a/examples/dropdown_test.py
+++ b/examples/dropdown_test.py
@@ -14,8 +14,8 @@ class TestDropdown(KeymapMovementMixin, Dropdown):
 
     KEYMAP = {
         "dropdown": {
-            "up": "up",
-            "down": "down",
+            "k": "up",
+            "j": "down",
             "page up": "page up",
             "page down": "page down",
             "home": "home",


### PR DESCRIPTION
When press `Down` in example, will move to next widget, and also the dropdown selected changed.

```
2018-02-27 10:18:41 [   DEBUG] select: Adipisci eius dolore consectetur.
2018-02-27 10:18:41 [   DEBUG] set_label: ('dropdown_text', 'Adipisci eius dolore consectetur.')
2018-02-27 10:18:41 [   DEBUG] select: Adipisci eius dolore consectetur.
2018-02-27 10:18:41 [   DEBUG] set_label: ('dropdown_text', 'Adipisci eius dolore consectetur.')
2018-02-27 10:18:41 [   DEBUG] select: Modi est ipsum adipisci
2018-02-27 10:18:41 [   DEBUG] set_label: ('dropdown_text', 'Modi est ipsum adipisci')
2018-02-27 10:18:41 [   DEBUG] select: Modi est ipsum adipisci
2018-02-27 10:18:41 [   DEBUG] set_label: ('dropdown_text', 'Modi est ipsum adipisci')
2018-02-27 10:18:41 [   DEBUG] set_label: ('dropdown_text', '∅')
2018-02-27 10:18:42 [   DEBUG] default keypress: down
2018-02-27 10:18:42 [   DEBUG] TestDropdown wrapped keypress: down
2018-02-27 10:18:42 [   DEBUG] select: Aliquam consectetur velit dolore
2018-02-27 10:18:42 [   DEBUG] set_label: ('dropdown_text', 'Aliquam consectetur velit dolore')
2018-02-27 10:18:43 [   DEBUG] default keypress: q
2018-02-27 10:18:43 [   DEBUG] TestDropdown wrapped keypress: q
```