### PR TITLE
bugfix: append_row index duplication

### DIFF
--- a/panwid/datatable/dataframe.py
+++ b/panwid/datatable/dataframe.py
@@ -51,6 +51,7 @@ class DataTableDataFrame(rc.DataFrame):
     def append_rows(self, rows):
 
         colnames =  list(self.columns)
+        length = len(rows)
 
         try:
             columns = list(set().union(*(list(d.keys()) for d in rows)))
@@ -61,7 +62,7 @@ class DataTableDataFrame(rc.DataFrame):
                 ))
             )
             if self.index_name not in columns:
-                index = list(range(len(self), len(list(data.values())[0])))
+                index = list(range(len(self), len(self) + length))
                 data[self.index_name] = index
             else:
                 index = data[self.index_name]


### PR DESCRIPTION
If you use `table.add_row(data)` but `index` not in `data`, you will have a `ValueError: duplicate indexes in DataFrames` .

I think this is because the wrong index generation. For example, if you already have 53 row, and when you want to add a new row, the index will be `index = list(range(len(self), len(self) + length))` , AKA `index = list(range(53, 1))` results `[]`.