### PR TITLE
bugfix: query default method

### DIFF
--- a/panwid/datatable/datatable.py
+++ b/panwid/datatable/datatable.py
@@ -297,7 +297,7 @@ class DataTable(urwid.WidgetWrap, urwid.listbox.ListWalker):
         super(DataTable, self).__init__(self.attr)
 
 
-    def query(self, sort=None, offset=None):
+    def query(self, sort=(None, None), offset=None, limit=None, load_all=False):
         raise Exception("query method must be overriden")
 
     def query_result_count(self):


### PR DESCRIPTION
Otherwise if user forget to overwrite `query`, user will get:

```
  File "/Users/laixintao/Program/urwid-datatable/urwid_datatable/datatable.py", line 301, in __init__
    self.reset()
  File "/Users/laixintao/Program/urwid-datatable/urwid_datatable/datatable.py", line 1012, in reset
    self.requery()
  File "/Users/laixintao/Program/urwid-datatable/urwid_datatable/datatable.py", line 797, in requery
    rows = list(self.query(**kwargs))
TypeError: query() got an unexpected keyword argument 'load_all'
```

After fix, user will get:
```
Exception: query method must be defined
```